### PR TITLE
feat: option for references file

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Default value: `true`
 
 Set to true to deploy the built documentation (API docs and/or blueprint and/or homepage) to GitHub Pages. (This is enabled by default but can be disabled for a dry run.)
 
+### input: `references`
+
+Default value: `references.bib`
+
+Path to a BibTeX (.bib) file used for generating the references page and link formatting.
+
 ## Deprecated Parameters
 
 The following parameter names are deprecated and will be removed in a future version:

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,10 @@ inputs:
   lake_package_directory:
     description: "DEPRECATED: Use lake-package-directory instead"
     required: false
+  references:
+    description: Path to a BibTeX (.bib) file used for generating the references page and link formatting.
+    required : false
+    default: "references.bib"
 runs:
   using: "composite"
   steps:
@@ -123,6 +127,7 @@ runs:
         NAME: ${{ steps.determine-project-metadata.outputs.name }}
         DOCS_FACETS: ${{ steps.determine-project-metadata.outputs.docs_facets }}
         HOMEPAGE: ${{ inputs.homepage }}
+        REFERENCES : ${{ inputs.references }}
 
     - name: Bundle dependencies
       if: github.event_name == 'push' && inputs.build-page == 'true' && env.DOCS_EXISTS == 'true'

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -79,6 +79,12 @@ EOF
 # Initialise docbuild as a Lean project
 cd docbuild
 
+# Place references.bib in the location expected by doc-gen4
+if [ -f ../$REFERENCES ]; then
+  mkdir -p docs
+  cp ../$REFERENCES ./docs/references.bib
+fi
+
 # Disable an error message due to a non-blocking bug. See Zulip
 MATHLIB_NO_CACHE_ON_UPDATE=1 ~/.elan/bin/lake update $NAME
 


### PR DESCRIPTION
This adds a `references` input that specifies a path to copy to `docs/references.bib` expected by `doc-gen4`.