### PR TITLE
fix: CI: include references in cache's key

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: ${{ steps.determine-project-metadata.outputs.cached_docbuild_dependencies }}
-        key: Docs-${{ hashFiles('lake-manifest.json') }}
+        key: Docs-${{ hashFiles('lake-manifest.json', inputs.references) }}
 
     - name: Check for ${{ inputs.homepage }} folder # this is meant to detect a Jekyll-based website
       id: check_docs


### PR DESCRIPTION
As in the title, fixes #18 