### PR TITLE
fix: swap order of doc-gen4 and parent project in generated docbuild lakefile.toml

### DIFF
--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -67,13 +67,13 @@ version = "0.1.0"
 packagesDir = "../.lake/packages"
 
 [[require]]
-name = "$NAME"
-path = "../"
-
-[[require]]
 scope = "leanprover"
 name = "doc-gen4"
 rev = "$DOC_GEN_REV"
+
+[[require]]
+name = "$NAME"
+path = "../"
 EOF
 
 # Initialise docbuild as a Lean project


### PR DESCRIPTION
If there is any version skew on shared dependencies, then this swap ensures that the user's versions take precedences over doc-build4's versions.

This prevents the cache invalidation reported in https://github.com/leanprover-community/docgen-action/issues/28
