### PR TITLE
feat: add a ruby-version input

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ The Ruby version used to build the Jekyll homepage (see the `homepage` input). T
 
 The value is passed to [ruby/setup-ruby](https://github.com/ruby/setup-ruby). Set it to `default` to read the version from a `.ruby-version`, `.tool-versions` or `mise.toml` file in the homepage folder. Set it to one of those file names to read that specific file. Quote the value in your workflow: an unquoted `3.0` in YAML becomes `3`.
 
+To pin the Ruby version in the project with one source of truth: put a full version (for example `3.4.3`) in a `.ruby-version` file in the homepage folder, set `ruby-version: default` in the workflow, and declare the same version in the homepage `Gemfile` with `ruby "3.4.3"`. Bundler then refuses to run with a different Ruby, and dependency update tools resolve gem updates against the pinned version.
+
 ## Deprecated Parameters
 
 The following parameter names are deprecated and will be removed in a future version:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ Path to a BibTeX (.bib) file used for generating the references page and link fo
 
 **Note:** If you don't have a `references.bib` file and encounter errors like `no such file or directory: references.bib`, this is a known issue in older versions of doc-gen4. It was fixed in [doc-gen4 PR #354](https://github.com/leanprover/doc-gen4/pull/354). Projects using Lean toolchains v4.28.0 or later will automatically get this fix. For older toolchains, you can work around this by creating an empty `references.bib` file in your repository root.
 
+### input: `ruby-version`
+
+Default value: `3.4`
+
+The Ruby version used to build the Jekyll homepage (see the `homepage` input). The action uses Ruby only for this purpose. Keep this version aligned with the `Gemfile.lock` in your homepage folder: to refresh the lockfile, run `bundle lock --update --add-platform x86_64-linux` on the same Ruby version.
+
+The value is passed to [ruby/setup-ruby](https://github.com/ruby/setup-ruby). Set it to `default` to read the version from a `.ruby-version`, `.tool-versions` or `mise.toml` file in the homepage folder. Set it to one of those file names to read that specific file. Quote the value in your workflow: an unquoted `3.0` in YAML becomes `3`.
+
 ## Deprecated Parameters
 
 The following parameter names are deprecated and will be removed in a future version:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Default value: `docs`
 
 If you would like more than just API documentation and a `blueprint` folder, this action automatically runs the [Jekyll](https://jekyllrb.com/) site generator for you. Run `jekyll new docs` in your project folder and commit the resulting `docs` folder. The action will automatically detect the `docs` folder and build it for you alongside the API documentation and the blueprint. After CI is complete, the compiled site will be available in `https://YOUR_USERNAME.github.io/YOUR_PROJECT_NAME`.
 
+When you set up the site, pin the Ruby version in the project: put a full version (for example `3.4.3`) in `docs/.ruby-version`, declare the same version in `docs/Gemfile` with `ruby "3.4.3"`, and set `ruby-version: default` in the workflow (see the `ruby-version` input below). One file then controls the Ruby version everywhere: this action reads it, Bundler refuses to run with a different Ruby, and dependency update tools resolve gem updates against it. When you later change the version, refresh `docs/Gemfile.lock` with `bundle lock --update --add-platform x86_64-linux` on the new Ruby.
+
 **Note:** The `docs` folder serves dual purposes: (1) it's the default location for your Jekyll site, and (2) the API documentation is placed in a `docs` subdirectory within it (i.e., `docs/docs/`). If you only want API documentation without a custom Jekyll site, you can set `build-page: false` to skip Jekyll entirely.
 
 ### input: `build-args`
@@ -119,7 +121,7 @@ The Ruby version used to build the Jekyll homepage (see the `homepage` input). T
 
 The value is passed to [ruby/setup-ruby](https://github.com/ruby/setup-ruby). Set it to `default` to read the version from a `.ruby-version`, `.tool-versions` or `mise.toml` file in the homepage folder. Set it to one of those file names to read that specific file. Quote the value in your workflow: an unquoted `3.0` in YAML becomes `3`.
 
-To pin the Ruby version in the project with one source of truth: put a full version (for example `3.4.3`) in a `.ruby-version` file in the homepage folder, set `ruby-version: default` in the workflow, and declare the same version in the homepage `Gemfile` with `ruby "3.4.3"`. Bundler then refuses to run with a different Ruby, and dependency update tools resolve gem updates against the pinned version.
+To pin the version in the project instead of the workflow, see the setup instructions in the `homepage` input above.
 
 ## Deprecated Parameters
 

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,15 @@ inputs:
     description: Path to a BibTeX (.bib) file used for generating the references page and link formatting.
     required: false
     default: "references.bib"
+  ruby-version:
+    description: |
+      The Ruby version used to build the Jekyll homepage.
+      Keep this aligned with the Gemfile.lock in your homepage folder.
+      The value is passed to ruby/setup-ruby, so it also accepts "default",
+      ".ruby-version", ".tool-versions" or "mise.toml" to read the version
+      from the corresponding file in the homepage folder.
+    required: false
+    default: "3.4"
   use-github-cache:
     description: Whether to use the GitHub Actions cache to accelerate the build. Defaults to true.
     required: false
@@ -146,7 +155,7 @@ runs:
       uses: ruby/setup-ruby@eaecf785f6a34567a6d97f686bbb7bccc1ac1e5c # v1.237.0
       with:
         working-directory: ${{ inputs.homepage }}
-        ruby-version: "3.4" # Specify Ruby version
+        ruby-version: ${{ inputs.ruby-version }}
         bundler-cache: true # Enable caching for bundler
 
     - name: Build website using Jekyll


### PR DESCRIPTION
The action hardcodes `ruby-version: "3.4"` for the Jekyll homepage build. The Ruby version must match the project's `Gemfile.lock`, but projects cannot change it. This broke ImperialCollegeLondon/FLT before #27 (a dependabot update needed Ruby >= 3.2, reverted in ImperialCollegeLondon/FLT#879) and broke emilyriehl/infinity-cosmos after it (a 2022 lockfile needed Ruby < 3.2, fixed in emilyriehl/infinity-cosmos#214).

This PR adds a `ruby-version` input, as suggested in [#27 (comment)](https://github.com/leanprover-community/docgen-action/pull/27#issuecomment-4183578063). The default is `"3.4"`, so nothing changes for current projects. The value goes to ruby/setup-ruby, so `default`, `.ruby-version`, `.tool-versions` and `mise.toml` also work: they read the version from the corresponding file in the homepage folder. Removing the version entirely would not be safe: setup-ruby [errors](https://github.com/ruby/setup-ruby/blob/eaecf785f6a34567a6d97f686bbb7bccc1ac1e5c/index.js#L115-L124) when it gets no version and finds no version file.

Tested on a [sandbox project](https://github.com/marcelolynch/docgen-sandbox) with the infinity-cosmos Gemfile and lockfile: [no input → Ruby 3.4](https://github.com/marcelolynch/docgen-sandbox/actions/runs/32387648530), [`"3.2"`](https://github.com/marcelolynch/docgen-sandbox/actions/runs/32387650955), [`default` + `.ruby-version` file](https://github.com/marcelolynch/docgen-sandbox/actions/runs/32387936322).

`action.yml` and README only; no change to `src/` or `dist/`.
