### PR TITLE
feat: validate the Jekyll build on pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ If you would like more than just API documentation and a `blueprint` folder, thi
 
 **Note:** The `docs` folder serves dual purposes: (1) it's the default location for your Jekyll site, and (2) the API documentation is placed in a `docs` subdirectory within it (i.e., `docs/docs/`). If you only want API documentation without a custom Jekyll site, you can set `build-page: false` to skip Jekyll entirely.
 
+The action builds the homepage on every event that triggers your workflow, so a `pull_request` event validates the Jekyll build before a merge. The API documentation build and the deployment to GitHub Pages run only on `push` events.
+
 ### input: `build-args`
 
 Default value: `--log-level=warning`

--- a/action.yml
+++ b/action.yml
@@ -142,7 +142,7 @@ runs:
         REFERENCES: ${{ inputs.references }}
 
     - name: Bundle dependencies
-      if: github.event_name == 'push' && inputs.build-page == 'true' && env.DOCS_EXISTS == 'true'
+      if: inputs.build-page == 'true' && env.DOCS_EXISTS == 'true'
       uses: ruby/setup-ruby@eaecf785f6a34567a6d97f686bbb7bccc1ac1e5c # v1.237.0
       with:
         working-directory: ${{ inputs.homepage }}
@@ -150,7 +150,7 @@ runs:
         bundler-cache: true # Enable caching for bundler
 
     - name: Build website using Jekyll
-      if: github.event_name == 'push' && inputs.build-page == 'true' && env.DOCS_EXISTS == 'true'
+      if: inputs.build-page == 'true' && env.DOCS_EXISTS == 'true'
       working-directory: ${{ inputs.homepage }}
       env:
         JEKYLL_GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
`Bundle dependencies` and `Build website using Jekyll` run only on `push` events, so a broken build only surfaces after a merge. This happened twice this year: ImperialCollegeLondon/FLT (dependabot update, reverted in ImperialCollegeLondon/FLT#879) and emilyriehl/infinity-cosmos (fixed in emilyriehl/infinity-cosmos#214, which could only be validated by pushing a temporary commit to a fork's `main`).

This PR removes the event check from these two steps only. They take about one minute together, and the blueprint steps already run on every event. The deploy, upload, API docs and cache steps keep their `push` gate: deploying from PRs would be wrong, and the API docs build is the expensive one (see #28).

This is the deploy-safe subset of the [`not-just-push`](https://github.com/leanprover-community/docgen-action/tree/not-just-push) branch: removing the gate on deploy would let a same-repository PR deploy to Pages with the README's example workflow.

Tested on a [sandbox project](https://github.com/marcelolynch/docgen-sandbox): [a PR run builds the site, deploy stays skipped](https://github.com/marcelolynch/docgen-sandbox/actions/runs/32387648530); [a PR run catches the infinity-cosmos lockfile breakage before merge](https://github.com/marcelolynch/docgen-sandbox/actions/runs/32387657486); [a push run is unchanged and deploys](https://github.com/marcelolynch/docgen-sandbox/actions/runs/32387591147).

`action.yml` and README only; no change to `src/` or `dist/`.
