### PR TITLE
feat: diagnose bundle install failures and propose a verified Gemfile.lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ The Ruby version used to build the Jekyll homepage (see the `homepage` input). T
 
 The value is passed to [ruby/setup-ruby](https://github.com/ruby/setup-ruby). Set it to `default` to read the version from a `.ruby-version`, `.tool-versions` or `mise.toml` file in the homepage folder. Set it to one of those file names to read that specific file. Quote the value in your workflow: an unquoted `3.0` in YAML becomes `3`.
 
+To pin the Ruby version in the project with one source of truth: put a full version (for example `3.4.3`) in a `.ruby-version` file in the homepage folder, set `ruby-version: default` in the workflow, and declare the same version in the homepage `Gemfile` with `ruby "3.4.3"`. Bundler then refuses to run with a different Ruby, and dependency update tools resolve gem updates against the pinned version.
+
 ## Deprecated Parameters
 
 The following parameter names are deprecated and will be removed in a future version:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ Path to a BibTeX (.bib) file used for generating the references page and link fo
 
 **Note:** If you don't have a `references.bib` file and encounter errors like `no such file or directory: references.bib`, this is a known issue in older versions of doc-gen4. It was fixed in [doc-gen4 PR #354](https://github.com/leanprover/doc-gen4/pull/354). Projects using Lean toolchains v4.28.0 or later will automatically get this fix. For older toolchains, you can work around this by creating an empty `references.bib` file in your repository root.
 
+### input: `ruby-version`
+
+Default value: `3.4`
+
+The Ruby version used to build the Jekyll homepage (see the `homepage` input). The action uses Ruby only for this purpose. Keep this version aligned with the `Gemfile.lock` in your homepage folder: to refresh the lockfile, run `bundle lock --update --add-platform x86_64-linux` on the same Ruby version.
+
+The value is passed to [ruby/setup-ruby](https://github.com/ruby/setup-ruby). Set it to `default` to read the version from a `.ruby-version`, `.tool-versions` or `mise.toml` file in the homepage folder. Set it to one of those file names to read that specific file. Quote the value in your workflow: an unquoted `3.0` in YAML becomes `3`.
+
 ## Deprecated Parameters
 
 The following parameter names are deprecated and will be removed in a future version:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Default value: `docs`
 
 If you would like more than just API documentation and a `blueprint` folder, this action automatically runs the [Jekyll](https://jekyllrb.com/) site generator for you. Run `jekyll new docs` in your project folder and commit the resulting `docs` folder. The action will automatically detect the `docs` folder and build it for you alongside the API documentation and the blueprint. After CI is complete, the compiled site will be available in `https://YOUR_USERNAME.github.io/YOUR_PROJECT_NAME`.
 
+When you set up the site, pin the Ruby version in the project: put a full version (for example `3.4.3`) in `docs/.ruby-version`, declare the same version in `docs/Gemfile` with `ruby "3.4.3"`, and set `ruby-version: default` in the workflow (see the `ruby-version` input below). One file then controls the Ruby version everywhere: this action reads it, Bundler refuses to run with a different Ruby, and dependency update tools resolve gem updates against it. When you later change the version, refresh `docs/Gemfile.lock` with `bundle lock --update --add-platform x86_64-linux` on the new Ruby.
+
 **Note:** The `docs` folder serves dual purposes: (1) it's the default location for your Jekyll site, and (2) the API documentation is placed in a `docs` subdirectory within it (i.e., `docs/docs/`). If you only want API documentation without a custom Jekyll site, you can set `build-page: false` to skip Jekyll entirely.
 
 ### input: `build-args`
@@ -119,7 +121,7 @@ The Ruby version used to build the Jekyll homepage (see the `homepage` input). T
 
 The value is passed to [ruby/setup-ruby](https://github.com/ruby/setup-ruby). Set it to `default` to read the version from a `.ruby-version`, `.tool-versions` or `mise.toml` file in the homepage folder. Set it to one of those file names to read that specific file. Quote the value in your workflow: an unquoted `3.0` in YAML becomes `3`.
 
-To pin the Ruby version in the project with one source of truth: put a full version (for example `3.4.3`) in a `.ruby-version` file in the homepage folder, set `ruby-version: default` in the workflow, and declare the same version in the homepage `Gemfile` with `ruby "3.4.3"`. Bundler then refuses to run with a different Ruby, and dependency update tools resolve gem updates against the pinned version.
+To pin the version in the project instead of the workflow, see the setup instructions in the `homepage` input above.
 
 ## Deprecated Parameters
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ If you would like more than just API documentation and a `blueprint` folder, thi
 
 **Note:** The `docs` folder serves dual purposes: (1) it's the default location for your Jekyll site, and (2) the API documentation is placed in a `docs` subdirectory within it (i.e., `docs/docs/`). If you only want API documentation without a custom Jekyll site, you can set `build-page: false` to skip Jekyll entirely.
 
+If `bundle install` fails in CI, the action diagnoses the failure. It retries with the committed `Gemfile.lock`, retries with a refreshed lockfile, and rebuilds the site to verify the result. When the refreshed lockfile fixes the problem, the action attaches it to the workflow run as the `refreshed-Gemfile.lock` artifact and explains the fix in the run summary. The run still fails, and nothing is relocked silently: download the artifact, review it, and commit it to your homepage folder.
+
 ### input: `build-args`
 
 Default value: `--log-level=warning`

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If you would like more than just API documentation and a `blueprint` folder, thi
 
 **Note:** The `docs` folder serves dual purposes: (1) it's the default location for your Jekyll site, and (2) the API documentation is placed in a `docs` subdirectory within it (i.e., `docs/docs/`). If you only want API documentation without a custom Jekyll site, you can set `build-page: false` to skip Jekyll entirely.
 
-If `bundle install` fails in CI, the action diagnoses the failure. It retries with the committed `Gemfile.lock`, retries with a refreshed lockfile, and rebuilds the site to verify the result. When the refreshed lockfile fixes the problem, the action attaches it to the workflow run as the `refreshed-Gemfile.lock` artifact and explains the fix in the run summary. The run still fails, and nothing is relocked silently: download the artifact, review it, and commit it to your homepage folder — or keep your lockfile and set the `ruby-version` input to a Ruby version that the lockfile supports.
+If `bundle install` fails in CI, the action diagnoses the failure. It retries with the committed `Gemfile.lock`, retries with a refreshed lockfile, and rebuilds the site to verify the result. When the refreshed lockfile repairs the install, the action attaches it to the workflow run as the `refreshed-Gemfile.lock` artifact, and the run summary states what the refreshed lockfile fixes and what it does not. The run still fails, and nothing is relocked silently: review and commit the artifact to your homepage folder, or keep your lockfile and set the `ruby-version` input to a Ruby version that the lockfile supports.
 
 ### input: `build-args`
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If you would like more than just API documentation and a `blueprint` folder, thi
 
 **Note:** The `docs` folder serves dual purposes: (1) it's the default location for your Jekyll site, and (2) the API documentation is placed in a `docs` subdirectory within it (i.e., `docs/docs/`). If you only want API documentation without a custom Jekyll site, you can set `build-page: false` to skip Jekyll entirely.
 
-If `bundle install` fails in CI, the action diagnoses the failure. It retries with the committed `Gemfile.lock`, retries with a refreshed lockfile, and rebuilds the site to verify the result. When the refreshed lockfile fixes the problem, the action attaches it to the workflow run as the `refreshed-Gemfile.lock` artifact and explains the fix in the run summary. The run still fails, and nothing is relocked silently: download the artifact, review it, and commit it to your homepage folder.
+If `bundle install` fails in CI, the action diagnoses the failure. It retries with the committed `Gemfile.lock`, retries with a refreshed lockfile, and rebuilds the site to verify the result. When the refreshed lockfile fixes the problem, the action attaches it to the workflow run as the `refreshed-Gemfile.lock` artifact and explains the fix in the run summary. The run still fails, and nothing is relocked silently: download the artifact, review it, and commit it to your homepage folder — or keep your lockfile and set the `ruby-version` input to a Ruby version that the lockfile supports.
 
 ### input: `build-args`
 

--- a/action.yml
+++ b/action.yml
@@ -142,12 +142,108 @@ runs:
         REFERENCES: ${{ inputs.references }}
 
     - name: Bundle dependencies
+      id: bundle
       if: github.event_name == 'push' && inputs.build-page == 'true' && env.DOCS_EXISTS == 'true'
       uses: ruby/setup-ruby@eaecf785f6a34567a6d97f686bbb7bccc1ac1e5c # v1.237.0
       with:
         working-directory: ${{ inputs.homepage }}
         ruby-version: "3.4" # Specify Ruby version
         bundler-cache: true # Enable caching for bundler
+
+    - name: Diagnose the failed bundle install
+      id: diagnose-bundle-failure
+      if: ${{ !cancelled() && steps.bundle.outcome == 'failure' }}
+      working-directory: ${{ inputs.homepage }}
+      env:
+        JEKYLL_GITHUB_TOKEN: ${{ github.token }}
+      shell: bash
+      run: |
+        # `bundle install` failed. Find out whether a refreshed Gemfile.lock
+        # fixes it: reproduce the failure with the committed lockfile, relock,
+        # install, and rebuild the site. Every command runs in (or installs
+        # into) a scratch directory, so the workspace and the build do not
+        # change. The step itself succeeds so the diagnosis is not reported
+        # as a second failure; the run stays red because `bundle` failed.
+        summary() { echo "$1" >> "$GITHUB_STEP_SUMMARY"; }
+        tail_to_summary() {
+          summary '```'
+          tail -n 15 "$1" >> "$GITHUB_STEP_SUMMARY"
+          summary '```'
+        }
+        summary '## `bundle install` failed: diagnosis'
+        if ! command -v bundle >/dev/null 2>&1; then
+          summary 'Ruby was not installed, so the failure comes before `bundle install`. Check the Ruby version and the setup-ruby log.'
+          exit 0
+        fi
+        scratch="$(mktemp -d)"
+        # Isolate from the .bundle/config that setup-ruby wrote before it failed.
+        export BUNDLE_APP_CONFIG="$scratch/.bundle"
+        export BUNDLE_PATH="$scratch/vendor"
+        cp Gemfile "$scratch/"
+        for f in Gemfile.lock .ruby-version .tool-versions mise.toml; do
+          if [ -f "$f" ]; then cp "$f" "$scratch/"; fi
+        done
+        ruby_desc="$(ruby -e 'print RUBY_DESCRIPTION')"
+
+        echo '::group::Reproduce with the committed Gemfile.lock'
+        if (cd "$scratch" && bundle install 2>&1 | tee reproduce.log); then
+          echo '::endgroup::'
+          summary "A second \`bundle install\` with the committed \`Gemfile.lock\` succeeded on this runner ($ruby_desc)."
+          summary 'The first failure looks transient (for example a network error). Re-run the job.'
+          exit 0
+        fi
+        echo '::endgroup::'
+
+        echo '::group::Refresh the lockfile'
+        if ! (cd "$scratch" && bundle lock --update --add-platform x86_64-linux aarch64-linux 2>&1 | tee lock.log); then
+          echo '::endgroup::'
+          summary 'The failure reproduces, and dependency resolution fails even without the lockfile pins.'
+          summary 'A refreshed lockfile does not fix this. Last lines of `bundle lock --update`:'
+          tail_to_summary "$scratch/lock.log"
+          exit 0
+        fi
+        echo '::endgroup::'
+
+        echo '::group::Install with the refreshed Gemfile.lock'
+        if ! (cd "$scratch" && bundle install 2>&1 | tee install.log); then
+          echo '::endgroup::'
+          summary 'The failure reproduces, and `bundle install` fails with a refreshed lockfile too.'
+          summary 'This does not look like a lockfile problem. Last lines:'
+          tail_to_summary "$scratch/install.log"
+          exit 0
+        fi
+        echo '::endgroup::'
+
+        echo '::group::Build the site with the refreshed Gemfile.lock'
+        built=true
+        if ! BUNDLE_GEMFILE="$scratch/Gemfile" JEKYLL_ENV=production \
+            bundle exec jekyll build --destination "$scratch/_site" 2>&1 | tee "$scratch/build.log"; then
+          built=false
+        fi
+        echo '::endgroup::'
+
+        mkdir -p "$scratch/artifact"
+        cp "$scratch/Gemfile.lock" "$scratch/artifact/Gemfile.lock"
+        echo "artifact-dir=$scratch/artifact" >> "$GITHUB_OUTPUT"
+        echo "upload=true" >> "$GITHUB_OUTPUT"
+        summary 'The failure reproduces with the committed `Gemfile.lock`, and it goes away with a refreshed one.'
+        if [ "$built" = true ]; then
+          summary "Verification on this runner ($ruby_desc): \`bundle install\` succeeds and Jekyll builds the site."
+        else
+          summary '`bundle install` succeeds with the refreshed lockfile, but `jekyll build` still fails, so the site needs more changes than the lockfile. Last lines:'
+          tail_to_summary "$scratch/build.log"
+        fi
+        summary ''
+        summary 'The refreshed `Gemfile.lock` is attached to this run as the `refreshed-Gemfile.lock` artifact.'
+        summary 'To fix the build, download the artifact and commit the file as `${{ inputs.homepage }}/Gemfile.lock`.'
+        summary 'Alternative: run `bundle lock --update --add-platform x86_64-linux` on the same Ruby version and commit the result.'
+
+    - name: Upload the refreshed Gemfile.lock
+      if: ${{ !cancelled() && steps.diagnose-bundle-failure.outputs.upload == 'true' }}
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: refreshed-Gemfile.lock
+        path: ${{ steps.diagnose-bundle-failure.outputs.artifact-dir }}
 
     - name: Build website using Jekyll
       if: github.event_name == 'push' && inputs.build-page == 'true' && env.DOCS_EXISTS == 'true'

--- a/action.yml
+++ b/action.yml
@@ -234,9 +234,11 @@ runs:
           tail_to_summary "$scratch/build.log"
         fi
         summary ''
-        summary 'The refreshed `Gemfile.lock` is attached to this run as the `refreshed-Gemfile.lock` artifact.'
-        summary 'To fix the build, download the artifact and commit the file as `${{ inputs.homepage }}/Gemfile.lock`.'
-        summary 'Alternative: run `bundle lock --update --add-platform x86_64-linux` on the same Ruby version and commit the result.'
+        summary 'The refreshed `Gemfile.lock` is attached to this run as the `refreshed-Gemfile.lock` artifact. Two ways to fix the build:'
+        summary '1. Download the artifact and commit the file as `${{ inputs.homepage }}/Gemfile.lock`. (Or run `bundle lock --update --add-platform x86_64-linux` on the same Ruby version and commit the result.)'
+        summary '2. Keep the current lockfile and set the `ruby-version` input of this action to a Ruby version that the lockfile supports. The bundler error above names the requirement.'
+        ruby_ver="$(ruby -e 'print RUBY_VERSION')"
+        echo "::error::bundle install failed with the committed ${{ inputs.homepage }}/Gemfile.lock, but succeeds with a refreshed lockfile on Ruby $ruby_ver. Fix: commit the refreshed-Gemfile.lock artifact from this run, or set the action's ruby-version input to a version that the current lockfile supports. Details in the run summary."
 
     - name: Upload the refreshed Gemfile.lock
       if: ${{ !cancelled() && steps.diagnose-bundle-failure.outputs.upload == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -175,6 +175,10 @@ runs:
           summary 'Ruby was not installed, so the failure comes before `bundle install`. Check the Ruby version and the setup-ruby log.'
           exit 0
         fi
+        if [ ! -f Gemfile ]; then
+          summary 'There is no `Gemfile` in `${{ inputs.homepage }}`, so the diagnosis cannot run. Check the setup-ruby log.'
+          exit 0
+        fi
         scratch="$(mktemp -d)"
         # Isolate from the .bundle/config that setup-ruby wrote before it failed.
         export BUNDLE_APP_CONFIG="$scratch/.bundle"
@@ -226,19 +230,21 @@ runs:
         cp "$scratch/Gemfile.lock" "$scratch/artifact/Gemfile.lock"
         echo "artifact-dir=$scratch/artifact" >> "$GITHUB_OUTPUT"
         echo "upload=true" >> "$GITHUB_OUTPUT"
-        summary 'The failure reproduces with the committed `Gemfile.lock`, and it goes away with a refreshed one.'
-        if [ "$built" = true ]; then
-          summary "Verification on this runner ($ruby_desc): \`bundle install\` succeeds and Jekyll builds the site."
-        else
-          summary '`bundle install` succeeds with the refreshed lockfile, but `jekyll build` still fails, so the site needs more changes than the lockfile. Last lines:'
-          tail_to_summary "$scratch/build.log"
-        fi
-        summary ''
-        summary 'The refreshed `Gemfile.lock` is attached to this run as the `refreshed-Gemfile.lock` artifact. Two ways to fix the build:'
-        summary '1. Download the artifact and commit the file as `${{ inputs.homepage }}/Gemfile.lock`. (Or run `bundle lock --update --add-platform x86_64-linux` on the same Ruby version and commit the result.)'
-        summary '2. Keep the current lockfile and set the `ruby-version` input of this action to a Ruby version that the lockfile supports. The bundler error above names the requirement.'
         ruby_ver="$(ruby -e 'print RUBY_VERSION')"
-        echo "::error::bundle install failed with the committed ${{ inputs.homepage }}/Gemfile.lock, but succeeds with a refreshed lockfile on Ruby $ruby_ver. Fix: commit the refreshed-Gemfile.lock artifact from this run, or set the action's ruby-version input to a version that the current lockfile supports. Details in the run summary."
+        summary 'The `bundle install` failure reproduces with the committed `Gemfile.lock` and goes away with a refreshed one.'
+        summary 'The refreshed `Gemfile.lock` is attached to this run as the `refreshed-Gemfile.lock` artifact.'
+        summary ''
+        if [ "$built" = true ]; then
+          summary "Verification on this runner ($ruby_desc): \`bundle install\` succeeds and Jekyll builds the site with the refreshed lockfile. Two ways to fix the build:"
+          summary '1. Download the artifact and commit the file as `${{ inputs.homepage }}/Gemfile.lock`. (Or run `bundle lock --update --add-platform x86_64-linux` on the same Ruby version and commit the result.)'
+          summary '2. Keep the current lockfile and set the `ruby-version` input of this action to a Ruby version that the lockfile supports. The `bundle install` error in the job log names the requirement.'
+          echo "::error::bundle install failed with the committed ${{ inputs.homepage }}/Gemfile.lock, but succeeds with a refreshed lockfile on Ruby $ruby_ver. Fix: commit the refreshed-Gemfile.lock artifact from this run, or set the action's ruby-version input to a version that the current lockfile supports. Details in the run summary."
+        else
+          summary 'However, `jekyll build` fails with the refreshed lockfile, so the refreshed lockfile alone does not fix the build. Last lines of `jekyll build`:'
+          tail_to_summary "$scratch/build.log"
+          summary 'Either update the site for the newer gem versions and commit the refreshed lockfile together with those changes, or keep the current lockfile and set the `ruby-version` input of this action to a Ruby version that the lockfile supports. The `bundle install` error in the job log names the requirement.'
+          echo "::error::bundle install failed with the committed ${{ inputs.homepage }}/Gemfile.lock. A refreshed lockfile repairs the install on Ruby $ruby_ver, but jekyll build then fails, so the refreshed lockfile alone does not fix the build. Details and options in the run summary."
+        fi
 
     - name: Upload the refreshed Gemfile.lock
       if: ${{ !cancelled() && steps.diagnose-bundle-failure.outputs.upload == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,15 @@ inputs:
     description: Path to a BibTeX (.bib) file used for generating the references page and link formatting.
     required: false
     default: "references.bib"
+  ruby-version:
+    description: |
+      The Ruby version used to build the Jekyll homepage.
+      Keep this aligned with the Gemfile.lock in your homepage folder.
+      The value is passed to ruby/setup-ruby, so it also accepts "default",
+      ".ruby-version", ".tool-versions" or "mise.toml" to read the version
+      from the corresponding file in the homepage folder.
+    required: false
+    default: "3.4"
   use-github-cache:
     description: Whether to use the GitHub Actions cache to accelerate the build. Defaults to true.
     required: false
@@ -146,7 +155,7 @@ runs:
       uses: ruby/setup-ruby@eaecf785f6a34567a6d97f686bbb7bccc1ac1e5c # v1.237.0
       with:
         working-directory: ${{ inputs.homepage }}
-        ruby-version: "3.4" # Specify Ruby version
+        ruby-version: ${{ inputs.ruby-version }}
         bundler-cache: true # Enable caching for bundler
 
     - name: Build website using Jekyll


### PR DESCRIPTION
(Stacked on top of #34: the proposed remedies name the `ruby-version` input)

When `bundle install` fails because the `Gemfile.lock` and the Ruby version drift apart, the maintainer must reproduce the runner environment to generate a correct lockfile (see emilyriehl/infinity-cosmos#214).

This PR adds a diagnosis step that runs only when `Bundle dependencies` fails. 

In a scratch directory it (1) reruns `bundle install` with the committed lockfile (2) runs `bundle lock --update`; (3) installs with the refreshed lockfile; (4) rebuilds the site with it. Only when the failure reproduces and the refreshed lockfile repairs the install, the action uploads it as the `refreshed-Gemfile.lock` artifact, and the run summary states what the refreshed lockfile fixes, what it does not, and how to commit it. The run still fails, and nothing is relocked silently.

Demo with the exact lockfile that broke infinity-cosmos: [the run fails and proposes the verified artifact](https://github.com/marcelolynch/docgen-sandbox/actions/runs/32387657486); [committing the artifact turns the run green](https://github.com/marcelolynch/docgen-sandbox/actions/runs/32388061285); [control: an unresolvable Gemfile uploads nothing](https://github.com/marcelolynch/docgen-sandbox/actions/runs/32387660737); [control: when the refreshed lockfile installs but Jekyll still fails, the messaging says the lockfile alone is not the fix](https://github.com/marcelolynch/docgen-sandbox/actions/runs/32390088323).

The setup instructions from #34 (pin the Ruby version in the project) prevent this drift for projects that adopt them. This diagnosis covers the projects that did not, and it keeps the forward fix (updated dependencies) as cheap as the backward one (pin an older Ruby).

`actions/upload-artifact` is pinned by commit (v4.6.2) like the other actions. `action.yml` and README only; no change to `src/` or `dist/`. Composes with #35: a dependabot PR that breaks resolution then fails on the PR itself, with the proposed lockfile attached to that run.
